### PR TITLE
Bumping octokit version for newer sawyer support

### DIFF
--- a/github_flo.gemspec
+++ b/github_flo.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "pry"
 
-  spec.add_dependency 'octokit', '~> 4.0.1'
+  spec.add_dependency 'octokit', '~> 4.6.0'
   spec.add_dependency 'flo', '>= 0.0.3'
 end


### PR DESCRIPTION
This will allow better ruby 2.4 support by updating the `addressable` as part of the `sawyer`, `octokit` upgrade.